### PR TITLE
libcufile v1.16.1.26

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 rdma_core:
-- '59'
+- '60'
 target_platform:
 - linux-64
 xz:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.28'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 rdma_core:
-- '59'
+- '60'
 target_platform:
 - linux-aarch64
 xz:

--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -164,7 +164,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/libcufile-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,4 @@
 arm_variant_type:  # [aarch64]
   - sbsa           # [aarch64]
 c_stdlib_version:  # [linux]
-  - 2.28           # [linux and aarch64]
-  - 2.17           # [linux and x86_64]
+  - 2.28           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libcufile" %}
-{% set version = "1.16.0.49" %}
+{% set version = "1.16.1.26" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -13,8 +13,8 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: e2bfa5e9a21257e5909e64f84c6902903d6f96595f15f4b36ee36c4d2cacf8a3  # [linux64]
-  sha256: d94244a91f7336df7a161126b13569345f85938cc557a5a7bce2cba43de9999b  # [aarch64]
+  sha256: f03d7d54aca5b94c679e6d6d078f3804e7115b77780981f73aa66fb208707084  # [linux64]
+  sha256: 24b83a4002ea78b46b17e5a0205ef70f64ec488baa0fd5fd69c08d81914146e4  # [aarch64]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libcufile" %}
-{% set version = "1.15.1.6" %}
-{% set cuda_version = "13.0" %}
+{% set version = "1.16.0.49" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-sbsa" %}  # [aarch64]
 {% set target_name = "x86_64-linux" %}  # [linux64]
@@ -13,8 +13,8 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 2c1f544ab1b0e215590d943cbd1b0a192a066e9b7592e605c2e28b22e886688f  # [linux64]
-  sha256: e41292a40bb89bb6f64e19972d3d9a209eddcbb96299a777b2edfa6b7d5b8777  # [aarch64]
+  sha256: e2bfa5e9a21257e5909e64f84c6902903d6f96595f15f4b36ee36c4d2cacf8a3  # [linux64]
+  sha256: d94244a91f7336df7a161126b13569345f85938cc557a5a7bce2cba43de9999b  # [aarch64]
 
 build:
   number: 0


### PR DESCRIPTION
libcufile 1.16.1.26

**Destination channel:** defaults

### Links

- [PKG-12016](https://anaconda.atlassian.net/browse/PKG-12016) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12016]: https://anaconda.atlassian.net/browse/PKG-12016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ