### PR TITLE
libcufile v1.14.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,7 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type:  # [aarch64]
   - sbsa           # [aarch64]
-  - tegra          # [aarch64]
+#  - tegra          # [aarch64]
 c_stdlib_version:  # [linux]
-  - 2.28           # [linux and aarch64]
-  - 2.17           # [linux and x86_64]
+  - "2.28"           # [linux and aarch64]
+#  - 2.17           # [linux and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,13 +20,13 @@ source:
   sha256: 196b61a1bf02b85e76c21bdfe414a3f4db4380df41d9212c9eb6d0aa92eee1ce  # [aarch64 and arm_variant_type=="tegra"]
 
 build:
-  number: 1
+  number: 0
   skip: true  # [not (linux64 or aarch64)]
 
 requirements:
   build:
     - cf-nvidia-tools 1.*  # [linux]
-    - patchelf <0.18.0                      # [linux]
+    - patchelf <0.18.0     # [linux]
 
 outputs:
   - name: libcufile
@@ -34,6 +34,15 @@ outputs:
       binary_relocation: false
       missing_dso_whitelist:
         - "*/libcuda.so.*"
+        # Needed for the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'     # [linux]
+        - '*libstdc++.so*'    # [linux]
+        - '*libmlx5.so*'      # [linux]
+        - '*libibverbs.so*'   # [linux]
+        - '*librdmacm.so*'    # [linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libcufile*.so*'   # [linux and aarch64]
     files:
       - lib/libcufile*.so.*
       - targets/{{ target_name }}/lib/libcufile*.so.*
@@ -74,10 +83,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Library for NVIDIA GPUDirect Storage
       description: |
         The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
+      dev_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
   - name: libcufile-dev
     build:
@@ -116,10 +127,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Library for NVIDIA GPUDirect Storage
       description: |
         The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
+      dev_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
   - name: libcufile-static
     files:
@@ -144,10 +157,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Library for NVIDIA GPUDirect Storage
       description: |
         The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
+      dev_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
   - name: gds-tools
     build:
@@ -183,20 +198,24 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Library for NVIDIA GPUDirect Storage
       description: |
         The cuFile library provides a direct data path between GPU memory and storage.
       doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
+      dev_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_file: LICENSE
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Library for NVIDIA GPUDirect Storage
   description: |
     The cuFile library provides a direct data path between GPU memory and storage.
   doc_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
+  dev_url: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libcufile 1.14.1.1

**Destination channel:** defaults

### Links

- [PKG-12782](https://anaconda.atlassian.net/browse/PKG-12782) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in fut


[PKG-12782]: https://anaconda.atlassian.net/browse/PKG-12782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ